### PR TITLE
add smart separation character option

### DIFF
--- a/test/date2name-test.el
+++ b/test/date2name-test.el
@@ -38,5 +38,34 @@
   (let ((old-path "/home/max/2018-06-01T13:45:18_test.txt"))
     (should (equal (date2name-remove-date old-path) "/home/max/test.txt"))))
 
+(ert-deftest date2name-smart-separation-uses-whitespace-character-for-separation-if-filename-contains-spaces-test
+    ()
+  (setq date2name-enable-smart-separation-character-chooser
+        t)
+  (let ((time (org-read-date nil t "<2018-07-03 02:00:00>"))
+        (filename "/home/max/original file.txt"))
+    (should (equal (date2name-prepend-date filename time t) "/home/max/2018-07-03T02.00.00 original file.txt"))))
+
+(ert-deftest date2name-smart-separation-uses-default-character-for-separation-if-filename-contains-no-spaces-test
+    ()
+  (setq date2name-enable-smart-separation-character-chooser
+        t)
+  (let ((time (org-read-date nil t "<2018-07-03 02:00:00>"))
+        (filename "/home/max/originalfile.txt"))
+    (should (equal (date2name-prepend-date filename time t) "/home/max/2018-07-03T02.00.00_originalfile.txt"))))
+
+(ert-deftest date2name-without-smart-separation-uses-default-character-for-separation-if-filename-contains-spaces-test
+    ()
+  (setq date2name-enable-smart-separation-character-chooser
+        nil)
+  (let ((time (org-read-date nil t "<2018-07-03 02:00:00>"))
+        (filename "/home/max/original file.txt"))
+    (should (equal (date2name-prepend-date filename time t) "/home/max/2018-07-03T02.00.00_original file.txt"))))
+
+(ert-deftest date2name-remove-can-remove-date-seperated-by-space-test
+    ()
+  (let ((old-path "/home/max/2018-06-01 test.txt"))
+    (should (equal (date2name-remove-date old-path) "/home/max/test.txt"))))
+
 
 ;;; date2name-test.el ends here


### PR DESCRIPTION
Solves  #1 by adding the possibility to automatically choose a space as a separator between timestamp and filename if the filename contains spaces (by setting `date2name-enable-smart-separation-character-chooser` to t). Accordingly the regexp for detecting timestamps in front of filenames must include the space.